### PR TITLE
Fixed suite build

### DIFF
--- a/T8/Form1.cs
+++ b/T8/Form1.cs
@@ -9106,9 +9106,9 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
             dt.Columns.Add("FLASHADDRESS", Type.GetType("System.Int32"));
             dt.Columns.Add("DESCRIPTION");
             T8Header fh = new T8Header();
-            fh.init(filename);
             if (ImportFromRepository)
             {
+                fh.init(filename);
                 string checkstring = fh.PartNumber + fh.SoftwareVersion;
                 string xmlfilename = System.Windows.Forms.Application.StartupPath + "\\repository\\" + Path.GetFileNameWithoutExtension(filename) + File.GetCreationTime(filename).ToString("yyyyMMddHHmmss") + checkstring + ".xml";
                 if (!Directory.Exists(System.Windows.Forms.Application.StartupPath + "\\repository"))
@@ -9142,6 +9142,7 @@ TrqMastCal.m_AirTorqMap -> 325 Nm = 1300 mg/c             * */
             bool createRepositoryFile = false;
             if (dt.Rows.Count == 0)
             {
+                fh.init(filename);
                 if (fh.SoftwareVersion.Trim().StartsWith("FD0M", StringComparison.OrdinalIgnoreCase))
                 {
                     if (MessageBox.Show("Do you want to load the known symbollist for FD0M files now?", "Question", MessageBoxButtons.YesNo) == DialogResult.Yes)

--- a/T8Test/VINDecoderTest.cs
+++ b/T8Test/VINDecoderTest.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Text;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using T8SuitePro;
+using CommonSuite;
 
 namespace T8Test
 {


### PR DESCRIPTION
With fresh installed environment, the suite build will not work (F6). This minor change allows a full suite build.
Also fixed the problem with symbol files not loading.